### PR TITLE
Parse entries for .dk that can be captured with single regex pass.

### DIFF
--- a/test/samples/expected/dk-hostmaster.dk
+++ b/test/samples/expected/dk-hostmaster.dk
@@ -1,0 +1,21 @@
+{
+    "domain_name":               "dk-hostmaster.dk",
+    "creation_date":             "1998-01-19 00:00:00",
+    "expiration_date":           "2022-03-31 00:00:00",
+    "registration_period":       "5 years",
+    "vid":                       "yes",
+    "dnssec":                    "Signed delegation",
+    "status":                    "Active",
+    "registrant_handle":         "DKHM1-DK",
+    "registrant_name":           "DK HOSTMASTER A/S",
+    "registrant_address":        "Ørestads Boulevard 108, 11.",
+    "registrant_postalcode":     "2300",
+    "registrant_city":           "København S",
+    "registrant_country":        "DK",
+    "administrator_handle":      "DKHM1-DK",
+    "administrator_name":        "DK HOSTMASTER A/S",
+    "administrator_address":     "Ørestads Boulevard 108, 11.",
+    "administrator_postalcode":  "2300",
+    "administrator_city":        "København S",
+    "administrator_country":     "DK"
+}

--- a/test/samples/whois/dk-hostmaster.dk
+++ b/test/samples/whois/dk-hostmaster.dk
@@ -1,0 +1,48 @@
+# Hello 127.0.0.1. Your session has been logged.
+#
+# Copyright (c) 2002 - 2018 by DK Hostmaster A/S
+#
+# Version: 2.0.2
+#
+# The data in the DK Whois database is provided by DK Hostmaster A/S
+# for information purposes only, and to assist persons in obtaining
+# information about or related to a domain name registration record.
+# We do not guarantee its accuracy. We will reserve the right to remove
+# access for entities abusing the data, without notice.
+# 
+# Any use of this material to target advertising or similar activities
+# are explicitly forbidden and will be prosecuted. DK Hostmaster A/S
+# requests to be notified of any such activities or suspicions thereof.
+
+Domain:               dk-hostmaster.dk
+DNS:                  dk-hostmaster.dk
+Registered:           1998-01-19
+Expires:              2022-03-31
+Registration period:  5 years
+VID:                  yes
+Dnssec:               Signed delegation
+Status:               Active
+
+Registrant
+Handle:               DKHM1-DK
+Name:                 DK HOSTMASTER A/S
+Address:              Ørestads Boulevard 108, 11.
+Postalcode:           2300
+City:                 København S
+Country:              DK
+
+Administrator
+Handle:               DKHM1-DK
+Name:                 DK HOSTMASTER A/S
+Address:              Ørestads Boulevard 108, 11.
+Postalcode:           2300
+City:                 København S
+Country:              DK
+
+Nameservers
+Hostname:             auth01.ns.dk-hostmaster.dk
+Handle:               DKHM1-DK
+Hostname:             auth02.ns.dk-hostmaster.dk
+Handle:               DKHM1-DK
+Hostname:             p.nic.dk
+Handle:               DKHM1-DK

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1243,12 +1243,26 @@ class WhoisDk(WhoisEntry):
     """Whois parser for .dk domains
     """
     regex = {
-        'domain_name':     'Domain: *(.+)',
-        'creation_date':   'Registered: *(.+)',
-        'expiration_date': 'Expires: *(.+)',
-        'dnssec':          'Dnssec: *(.+)',
-        'status':          'Status: *(.+)',
-        'name_servers':     'Nameservers\n *([\n\S\s]+)'
+        'domain_name':              'Domain: *(.+)',
+        'creation_date':            'Registered: *(.+)',
+        'expiration_date':          'Expires: *(.+)',
+        'registration_period':      'Registration period: *(.+)',
+        'vid':                      'VID: *(.+)',
+        'dnssec':                   'Dnssec: *(.+)',
+        'status':                   'Status: *(.+)',
+        'registrant_handle':        'Registrant\n(?:.+:.+\n)*Handle: *(.+)',
+        'registrant_name':          'Registrant\n(?:.+:.+\n)*Name: *(.+)',
+        'registrant_address':       'Registrant\n(?:.+:.+\n)*Address: *(.+)',
+        'registrant_postalcode':    'Registrant\n(?:.+:.+\n)*Postalcode: *(.+)',
+        'registrant_city':          'Registrant\n(?:.+:.+\n)*City: *(.+)',
+        'registrant_country':       'Registrant\n(?:.+:.+\n)*Country: *(.+)',
+        'administrator_handle':     'Administrator\n(?:.+:.+\n)*Handle: *(.+)',
+        'administrator_name':       'Administrator\n(?:.+:.+\n)*Name: *(.+)',
+        'administrator_address':    'Administrator\n(?:.+:.+\n)*Address: *(.+)',
+        'administrator_postalcode': 'Administrator\n(?:.+:.+\n)*Postalcode: *(.+)',
+        'administrator_city':       'Administrator\n(?:.+:.+\n)*City: *(.+)',
+        'administrator_country':    'Administrator\n(?:.+:.+\n)*Country: *(.+)',
+        # 'name_servers':     'Nameservers\n *([\n\S\s]+)'
     }
 
     def __init__(self, domain, text):


### PR DESCRIPTION
closes #1 

Fields excluded by above clause: Name server hostnames and handles
